### PR TITLE
Use the repository instead of the homepage field in Cargo.toml

### DIFF
--- a/orbit2-sys/Cargo.toml
+++ b/orbit2-sys/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "A Rust binding for the ORBit2 Gnome CORBA library"
 license = "MIT"
 documentation = "https://github.com/jeteve/orbit2-rs"
-homepage = "https://github.com/jeteve/orbit2-rs"
+repository = "https://github.com/jeteve/orbit2-rs"
 
 [dependencies]
 log = ">=0.4.21"


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.